### PR TITLE
feat: implement labeledButton with new approach

### DIFF
--- a/src/components/labeled-button.tsx
+++ b/src/components/labeled-button.tsx
@@ -1,41 +1,32 @@
 import React from 'react';
-import { ButtonProps, Flex, ForwardRef, IconButton, Label } from 'theme-ui';
+import { Button, ButtonProps, ForwardRef, ThemeUIStyleObject } from 'theme-ui';
 
 export interface LabeledButtonProps extends ButtonProps {
-  label: string;
   name?: string;
+  sx?: ThemeUIStyleObject;
 }
 
 export const LabeledButton: ForwardRef<HTMLButtonElement, LabeledButtonProps> =
-  React.forwardRef(({ label, name, children, ...props }, ref) => {
+  React.forwardRef(({ name, children, sx, ...props }, ref) => {
     return (
-      <Flex sx={{ alignItems: 'center' }}>
-        <Label
-          htmlFor={name}
-          sx={{
-            width: 'auto',
-            flexGrow: 1,
-            color: 'black',
-            fontWeight: 'body',
-            marginRight: 1,
-            cursor: 'pointer',
-          }}
-        >
-          {label}
-        </Label>
-        <IconButton
-          {...props}
-          ref={ref}
-          id={name}
-          name={name}
-          sx={{
-            flexGrow: 3,
-            cursor: 'pointer',
-          }}
-        >
-          {children}
-        </IconButton>
-      </Flex>
+      <Button
+        mr={3}
+        sx={{
+          color: 'text',
+          ...sx,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+          gap: 2,
+        }}
+        {...props}
+        ref={ref}
+        id={name}
+        name={name}
+      >
+        {children}
+      </Button>
     );
   });
 

--- a/src/stories/labeled-button.stories.tsx
+++ b/src/stories/labeled-button.stories.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {
+  HiOutlineAcademicCap,
+  HiOutlineAdjustments,
+  HiOutlineArchive,
+  HiOutlineArrowNarrowRight,
+  HiOutlineCloudDownload,
+  HiOutlinePlus,
+  HiOutlineViewGridAdd,
+} from 'react-icons/hi';
+import { Text } from 'theme-ui';
+import { LabeledButton } from '../components/labeled-button';
+
+export default {
+  title: 'LabeledButton',
+  component: LabeledButton,
+  parameters: { actions: { argTypesRegex: '^on.*' } },
+};
+
+export const Delete: React.FC = () => (
+  <LabeledButton
+    sx={{
+      backgroundColor: 'lightRed',
+      color: 'text',
+      borderRadius: '8px',
+      cursor: 'pointer',
+    }}
+    onClick={() => alert('Button clicked!')}
+  >
+    <Text>Delete</Text>
+    <HiOutlineArchive />
+  </LabeledButton>
+);
+
+export const AffixedIcon: React.FC = () => (
+  <LabeledButton
+    sx={{
+      backgroundColor: 'lightGreen',
+      color: 'text',
+      borderRadius: '8px',
+      cursor: 'pointer',
+    }}
+    onClick={() => alert('Button clicked!')}
+  >
+    <HiOutlinePlus />
+    <Text>Add something</Text>
+  </LabeledButton>
+);
+
+export const Download: React.FC = () => (
+  <LabeledButton
+    sx={{
+      backgroundColor: 'lightYellow',
+      color: 'text',
+      borderRadius: '8px',
+      cursor: 'pointer',
+    }}
+    onClick={() => alert('Button clicked!')}
+  >
+    <Text>Download</Text>
+    <HiOutlineCloudDownload />
+  </LabeledButton>
+);
+
+export const JustIcon: React.FC = () => (
+  <LabeledButton
+    sx={{
+      backgroundColor: 'lightYellow',
+      color: 'text',
+      borderRadius: '8px',
+      cursor: 'pointer',
+    }}
+    onClick={() => alert('Button clicked!')}
+  >
+    <HiOutlineAcademicCap />
+  </LabeledButton>
+);
+
+export const ManyIcons: React.FC = () => (
+  <LabeledButton
+    sx={{
+      backgroundColor: 'lightGreen',
+      color: 'text',
+      borderRadius: '8px',
+      cursor: 'pointer',
+    }}
+    onClick={() => alert('Button clicked!')}
+  >
+    <HiOutlineAdjustments />
+    <HiOutlineArrowNarrowRight />
+    <HiOutlineViewGridAdd />
+    <HiOutlineCloudDownload />
+  </LabeledButton>
+);


### PR DESCRIPTION
- No longer use `label` prop, instead use `<Text>` as child element
- Can add many different icons, order text as we wish
- Items are aligned
- Whole element is clickable
- Responds to sx styling as we would expect

`sx = {{variant: 'buttons.large'}}` is not tested.